### PR TITLE
core/dotCMS#27440 send proper request params

### DIFF
--- a/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
@@ -5,7 +5,4 @@ import com.dotmarketing.util.json.JSONObject;
 public interface OpenAIChatService {
 
     JSONObject sendTextPrompt(String prompt);
-
-    JSONObject sendRawRequest(JSONObject prompt);
-
 }

--- a/src/main/java/com/dotcms/ai/service/OpenAIChatServiceImpl.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIChatServiceImpl.java
@@ -5,12 +5,11 @@ import com.dotcms.ai.app.AppKeys;
 import com.dotcms.ai.util.OpenAIRequest;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.json.JSONObject;
+
 import java.util.List;
 import java.util.Map;
 
 public class OpenAIChatServiceImpl implements OpenAIChatService {
-
-
     final AppConfig config;
 
     public OpenAIChatServiceImpl(AppConfig appConfig) {
@@ -18,35 +17,18 @@ public class OpenAIChatServiceImpl implements OpenAIChatService {
         this.config=appConfig;
     }
 
-
-
-
-
-
-    public JSONObject sendTextPrompt(String textPrompt) {
-
-        JSONObject newPrompt = new JSONObject();
-        newPrompt.put("prompt", textPrompt);
-        return sendRawRequest(newPrompt);
-    }
-
-    public JSONObject sendRawRequest(JSONObject prompt) {
-
-        prompt.putIfAbsent("model",config.getModel());
-        prompt.putIfAbsent("temp",config.getConfigFloat(AppKeys.COMPLETION_TEMPERATURE));
-        if(UtilMethods.isEmpty(prompt.optString("messages"))){
+    public JSONObject sendTextPrompt(String prompt) {
+        JSONObject request = new JSONObject();
+        request.putIfAbsent("model",config.getModel());
+        request.putIfAbsent("temperature",config.getConfigFloat(AppKeys.COMPLETION_TEMPERATURE));
+        if(UtilMethods.isEmpty(request.optString("messages"))){
             List messages = List.of(
-                    Map.of("role",config.getRolePrompt(), "content", config.getRolePrompt()),
-                    Map.of("role","user", "content", prompt.getString("prompt"))
+                    Map.of("role","system", "content", config.getRolePrompt()),
+                    Map.of("role","user", "content", prompt)
             );
-            prompt.put("messages", messages);
+            request.put("messages", messages);
 
         }
-        return new JSONObject(OpenAIRequest.doRequest(config.getApiUrl(),"POST",config.getApiKey(),prompt)) ;
-
-
-
+        return new JSONObject(OpenAIRequest.doRequest(config.getApiUrl(),"POST",config.getApiKey(),request)) ;
     }
-
-
 }

--- a/src/main/java/com/dotcms/ai/viewtool/AIViewTool.java
+++ b/src/main/java/com/dotcms/ai/viewtool/AIViewTool.java
@@ -35,29 +35,8 @@ public class AIViewTool implements ViewTool {
      * @return JSONObject
      */
     public JSONObject generateText(final String prompt) throws IOException {
-        return generateText(prompt, false);
-    }
-
-    /**
-     * Processes image request by calling TextService.
-     *
-     * @param prompt
-     * @param raw
-     * @return
-     * @throws IOException
-     */
-    private JSONObject generateText(String prompt, boolean raw) throws IOException {
-
         OpenAIChatService service = new OpenAIChatServiceImpl(config);
-        return raw ? service.sendRawRequest(new JSONObject(prompt)) : service.sendTextPrompt(prompt);
-
-
-    }
-
-    public JSONObject generateText(final JSONObject prompt) throws IOException {
-
-        OpenAIChatService service = new OpenAIChatServiceImpl(config);
-        return service.sendRawRequest(prompt);
+        return service.sendTextPrompt(prompt);
     }
 
     /**


### PR DESCRIPTION
Some changes to the request to make it work
* Change `temp` to `temperature`
* Set `role`  to `system` instead of `$rolePrompt`
* Remove invalid `prompt` param. This was making the response being a 400 bad request .
* Remove tool signature taking JSON Object  `generateText(final JSONObject prompt)` and leave only the one taking string. We were doing: 
``` public JSONObject sendTextPrompt(String textPrompt) {
        JSONObject newPrompt = new JSONObject();
        newPrompt.put("prompt", textPrompt);
        return sendRawRequest(newPrompt);
```
which is invalid. The actual prompt goes deep down inside the JSON which is constructed inside `OpenAIChatService`
I think leaving the `String` signature for now is ok. 