### PR TITLE
dotCMS/core#27468 fix and restore JSON signature of generateText

### DIFF
--- a/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
@@ -4,7 +4,28 @@ import com.dotmarketing.util.json.JSONObject;
 
 public interface OpenAIChatService {
 
+    /**
+     * Returns a JSONObject with the results of the text generation given the provided prompt
+     * @param prompt a String representing the provided prompt to generate text
+     * @return a JSONObject including the generated text and metadata
+     */
     JSONObject sendTextPrompt(String prompt);
 
+    /**
+     * Returns a JSONObject with the results of the text generation given the provided prompt
+     * @param prompt the provided prompt, as JSON, to generate text
+     * @return a JSONObject including the generated text and metadata
+     * <p>
+     * Example of usage:
+     * <p>
+     * <pre>{@code
+     *  JSONObject prompt = new JSONObject();
+     *  prompt.put("model","gpt-3.5-turbo-16k");
+     *  prompt.put("temperature",1);
+     *  prompt.put("prompt","Short text about dotCMS");
+     *  sendRawRequest(prompt);
+     * }</pre>
+     *
+     */
     JSONObject sendRawRequest(JSONObject prompt);
 }

--- a/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
@@ -5,4 +5,6 @@ import com.dotmarketing.util.json.JSONObject;
 public interface OpenAIChatService {
 
     JSONObject sendTextPrompt(String prompt);
+
+    JSONObject sendRawRequest(JSONObject prompt);
 }

--- a/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIChatService.java
@@ -13,7 +13,13 @@ public interface OpenAIChatService {
 
     /**
      * Returns a JSONObject with the results of the text generation given the provided prompt
-     * @param prompt the provided prompt, as JSON, to generate text
+     * @param prompt the provided prompt, as JSON, to generate text. The available properties
+     *               for the JSON are:
+     * <ul>
+     * <li>{@code "prompt"}: the actual prompt text
+     * <li>{@code "model"}: the model used for the generation
+     * <li>{@code "temperature"}: Temperature ranges from 0 to 1. Low temperature (0 to 0.3): More focused, coherent, and conservative outputs. Medium temperature (0.3 to 0.7): Balanced creativity and coherence. High temperature (0.7 to 1): Highly creative and diverse, but potentially less coherent.
+     * </ul>
      * @return a JSONObject including the generated text and metadata
      * <p>
      * Example of usage:

--- a/src/main/java/com/dotcms/ai/service/OpenAIChatServiceImpl.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIChatServiceImpl.java
@@ -17,18 +17,27 @@ public class OpenAIChatServiceImpl implements OpenAIChatService {
         this.config=appConfig;
     }
 
-    public JSONObject sendTextPrompt(String prompt) {
-        JSONObject request = new JSONObject();
-        request.putIfAbsent("model",config.getModel());
-        request.putIfAbsent("temperature",config.getConfigFloat(AppKeys.COMPLETION_TEMPERATURE));
-        if(UtilMethods.isEmpty(request.optString("messages"))){
+    @Override
+    public JSONObject sendTextPrompt(String textPrompt) {
+        JSONObject newPrompt = new JSONObject();
+        newPrompt.put("prompt", textPrompt);
+        return sendRawRequest(newPrompt);
+    }
+
+    @Override
+    public JSONObject sendRawRequest(JSONObject prompt) {
+        prompt.putIfAbsent("model",config.getModel());
+        prompt.putIfAbsent("temperature",config.getConfigFloat(AppKeys.COMPLETION_TEMPERATURE));
+
+        if(UtilMethods.isEmpty(prompt.optString("messages"))){
             List messages = List.of(
                     Map.of("role","system", "content", config.getRolePrompt()),
-                    Map.of("role","user", "content", prompt)
+                    Map.of("role","user", "content", prompt.getString("prompt"))
             );
-            request.put("messages", messages);
-
+            prompt.put("messages", messages);
         }
-        return new JSONObject(OpenAIRequest.doRequest(config.getApiUrl(),"POST",config.getApiKey(),request)) ;
+
+        prompt.remove("prompt");
+        return new JSONObject(OpenAIRequest.doRequest(config.getApiUrl(),"POST",config.getApiKey(),prompt));
     }
 }

--- a/src/main/java/com/dotcms/ai/service/OpenAIImageServiceImpl.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIImageServiceImpl.java
@@ -70,9 +70,14 @@ public class OpenAIImageServiceImpl implements OpenAIImageService {
             responseString = OpenAIRequest.doRequest(config.getApiImageUrl(), "POST", config.getApiKey(),
                     jsonObject);
 
-            JSONObject returnObject = new JSONObject(responseString).getJSONArray("data").getJSONObject(0);
-            returnObject.put("originalPrompt", jsonObject.getString("prompt"));
+            JSONObject returnObject = new JSONObject(responseString);
 
+            if(returnObject.containsKey("error")) {
+                throw new DotRuntimeException("Error generating image: " + returnObject.get("error"));
+            } else {
+                returnObject = returnObject.getJSONArray("data").getJSONObject(0);
+                returnObject.put("originalPrompt", jsonObject.getString("prompt"));
+            }
 
             return createTempFile(returnObject);
 

--- a/src/main/java/com/dotcms/ai/viewtool/AIViewTool.java
+++ b/src/main/java/com/dotcms/ai/viewtool/AIViewTool.java
@@ -39,6 +39,11 @@ public class AIViewTool implements ViewTool {
         return service.sendTextPrompt(prompt);
     }
 
+    public JSONObject generateText(final Map<String, Object> prompt) throws IOException {
+        OpenAIChatService service = new OpenAIChatServiceImpl(config);
+        return service.sendRawRequest(new JSONObject(prompt));
+    }
+
     /**
      * Processes image request by calling ImageService. If response is OK creates temp file and adds its name in
      * response
@@ -46,7 +51,7 @@ public class AIViewTool implements ViewTool {
      * @param prompt
      * @return
      */
-    private JSONObject generateImage(String prompt) {
+    public JSONObject generateImage(String prompt) {
         User user = PortalUtil.getUser(context.getRequest());
         OpenAIImageService service = new OpenAIImageServiceImpl(config, user);
         try {
@@ -60,7 +65,7 @@ public class AIViewTool implements ViewTool {
         }
     }
 
-    private JSONObject generateImage(Map prompt) {
+    public JSONObject generateImage(final Map<String, Object> prompt) {
         User user = PortalUtil.getUser(context.getRequest());
         OpenAIImageService service = new OpenAIImageServiceImpl(config, user);
         try {


### PR DESCRIPTION
* Fixed and restored the version of `$ai.generateText` which takes a Map.  This is important to have since it can take custom config values instead of the ones set at portlet level
* Made the `$ai.generateImage` methods public. Both were private. 
* Send back to user the actual error messages / proper handing of the "error" responses on the ImageService. 