### PR TITLE
Only index live content and other improvements

### DIFF
--- a/src/main/java/com/dotcms/ai/api/BulkEmbeddingsRunner.java
+++ b/src/main/java/com/dotcms/ai/api/BulkEmbeddingsRunner.java
@@ -30,7 +30,7 @@ public class BulkEmbeddingsRunner implements Runnable {
             try {
 
                 Contentlet contentlet = APILocator.getContentletAPI().find(inode, user, false);
-                if (UtilMethods.isEmpty(contentlet::getContentType)) {
+                if (UtilMethods.isEmpty(contentlet::getContentType) || !contentlet.isLive()) {
                     continue;
                 }
 

--- a/src/main/java/com/dotcms/ai/api/CompletionsAPIImpl.java
+++ b/src/main/java/com/dotcms/ai/api/CompletionsAPIImpl.java
@@ -176,7 +176,7 @@ public class CompletionsAPIImpl implements CompletionsAPI {
     }
 
     private int countTokens(String testString) {
-        Optional<Encoding> encoderOpt = EncodingUtil.registry.getEncodingForModel(config.get().getConfig(AppKeys.COMPLETION_MODEL));
+        Optional<Encoding> encoderOpt = EncodingUtil.registry.getEncodingForModel(config.get().getConfig(AppKeys.MODEL));
         if (encoderOpt.isEmpty()) {
             throw new DotRuntimeException("Encoder not found");
         }
@@ -271,7 +271,7 @@ public class CompletionsAPIImpl implements CompletionsAPI {
     private JSONObject buildRequestJson(CompletionsForm form) {
 
 
-        int maxTokenSize = OpenAIModel.resolveModel(config.get().getConfig(AppKeys.COMPLETION_MODEL)).maxTokens;
+        int maxTokenSize = OpenAIModel.resolveModel(config.get().getConfig(AppKeys.MODEL)).maxTokens;
 
 
         int promptTokens = countTokens(form.prompt);
@@ -283,7 +283,7 @@ public class CompletionsAPIImpl implements CompletionsAPI {
 
         JSONObject json = new JSONObject();
         json.put("messages", messages);
-        json.putIfAbsent("model", config.get().getConfig(AppKeys.COMPLETION_MODEL));
+        json.putIfAbsent("model", config.get().getConfig(AppKeys.MODEL));
 
         json.put("temperature", form.temperature);
         if (form.responseLengthTokens > 0) {

--- a/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
+++ b/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
@@ -87,9 +87,17 @@ class EmbeddingsAPIImpl implements EmbeddingsAPI {
                 }
                 newOffset += limit;
                 for(ContentletSearch row : searchResults){
+
+                    String esId = row.getId();
+                    long languageId = Try.of(()->esId.split("_")[1]).map(Long::parseLong).getOrElse(-1L);
+
                     Builder dto = new EmbeddingsDTO.Builder()
-                            .withIdentifier(row.getIdentifier())
-                            .withInode(row.getInode());
+                            .withIdentifier(row.getIdentifier());
+                    if(languageId>0){
+                        dto.withLanguage((int)languageId);
+                    }else{
+                        dto.withInode(row.getInode());
+                    }
 
                     if(indexName.isPresent()){
                         dto.withIndexName(indexName.get());

--- a/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
+++ b/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
@@ -74,14 +74,14 @@ class EmbeddingsAPIImpl implements EmbeddingsAPI {
     public int deleteByQuery(@NotNull String deleteQuery, Optional<String> indexName, User user) {
 
         int total=0;
-        int limit = 1000;
+        final int limit = 100;
         int newOffset = 0;
         try {
 
             for (int i = 0; i < 10000; i++) {
 
                 // searchIndex(String luceneQuery, int limit, int offset, String sortBy, User user, boolean respectFrontendRoles)
-                List<ContentletSearch> searchResults = APILocator.getContentletAPI().searchIndex(deleteQuery, 100, newOffset, "moddate", user, false);
+                List<ContentletSearch> searchResults = APILocator.getContentletAPI().searchIndex(deleteQuery, limit, newOffset, "moddate", user, false);
                 if (searchResults.isEmpty()) {
                     break;
                 }

--- a/src/main/java/com/dotcms/ai/app/AppKeys.java
+++ b/src/main/java/com/dotcms/ai/app/AppKeys.java
@@ -12,7 +12,6 @@ public enum AppKeys {
     MODEL("model", "gpt-3.5-turbo-16k"),
     IMAGE_MODEL("imageModel", "dall-e-3"),
     DEBUG_LOGGING("com.dotcms.ai.debug.logging", "false"),
-    COMPLETION_MODEL("com.dotcms.ai.completion.model", "gpt-3.5-turbo-16k"),
     COMPLETION_TEMPERATURE("com.dotcms.ai.completion.default.temperature", "1"),
     COMPLETION_ROLE_PROMPT("com.dotcms.ai.completion.role.prompt",
             "You are a helpful assistant with a descriptive writing style."),

--- a/src/main/java/com/dotcms/ai/db/EmbeddingsDB.java
+++ b/src/main/java/com/dotcms/ai/db/EmbeddingsDB.java
@@ -112,7 +112,7 @@ public class EmbeddingsDB {
      * @throws SQLException
      */
     private Connection getPGVectorConnection() throws SQLException {
-        Connection conn = DbConnectionFactory.getDataSource().getConnection();
+        Connection conn = PgVectorDataSource.datasource.get().getConnection();
         PGvector.addVectorType(conn);
         return conn;
     }

--- a/src/main/java/com/dotcms/ai/db/PgVectorDataSource.java
+++ b/src/main/java/com/dotcms/ai/db/PgVectorDataSource.java
@@ -1,0 +1,45 @@
+package com.dotcms.ai.db;
+
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.UtilMethods;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.vavr.Lazy;
+import javax.sql.DataSource;
+
+
+class PgVectorDataSource {
+
+
+    public static final Lazy<DataSource> datasource = Lazy.of(() -> resolveDataSource());
+
+
+
+    private static DataSource resolveDataSource() {
+        if (UtilMethods.isEmpty(Config.getStringProperty("AI_DB_BASE_URL", null))) {
+            return DbConnectionFactory.getDataSource();
+        }
+        return internalDatasource();
+
+
+    }
+
+    private static DataSource internalDatasource() {
+        String userName = Config.getStringProperty("AI_DB_USERNAME");
+        String password = Config.getStringProperty("AI_DB_PASSWORD");
+        String dbUrl = Config.getStringProperty("AI_DB_BASE_URL");
+        int maxConnections = Config.getIntProperty("AI_DB_MAX_TOTAL", 50);
+
+        final HikariConfig config = new HikariConfig();
+        config.setUsername(userName);
+        config.setPassword(password);
+        config.setJdbcUrl(dbUrl);
+        config.setMaximumPoolSize(maxConnections);
+        return new HikariDataSource(config);
+
+
+    }
+
+
+}

--- a/src/main/java/com/dotcms/ai/db/PgVectorDataSource.java
+++ b/src/main/java/com/dotcms/ai/db/PgVectorDataSource.java
@@ -6,16 +6,25 @@ import com.dotmarketing.util.UtilMethods;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.vavr.Lazy;
+
 import javax.sql.DataSource;
 
-
+/**
+ * This class will return the Datasource that is configured for the ai plugin, or will return the default datasource if no specific DB is configured for AI
+ */
 class PgVectorDataSource {
 
-
+    /**
+     * returns the configured datasource
+     */
     public static final Lazy<DataSource> datasource = Lazy.of(() -> resolveDataSource());
 
 
-
+    /**
+     * Checks if a specific AI datasource is provided, if not, returns the standard dotCMS datasource
+     *
+     * @return
+     */
     private static DataSource resolveDataSource() {
         if (UtilMethods.isEmpty(Config.getStringProperty("AI_DB_BASE_URL", null))) {
             return DbConnectionFactory.getDataSource();
@@ -25,6 +34,11 @@ class PgVectorDataSource {
 
     }
 
+    /**
+     * Builds the ai specific datasource.
+     *
+     * @return
+     */
     private static DataSource internalDatasource() {
         String userName = Config.getStringProperty("AI_DB_USERNAME");
         String password = Config.getStringProperty("AI_DB_PASSWORD");

--- a/src/main/java/com/dotcms/ai/rest/EmbeddingsResource.java
+++ b/src/main/java/com/dotcms/ai/rest/EmbeddingsResource.java
@@ -74,7 +74,7 @@ public class EmbeddingsResource {
             for (int i = 0; i < 10000; i++) {
 
                 // searchIndex(String luceneQuery, int limit, int offset, String sortBy, User user, boolean respectFrontendRoles)
-                List<ContentletSearch> searchResults = APILocator.getContentletAPI().searchIndex(embeddingsForm.query, embeddingsForm.limit, newOffset, "moddate", user, false);
+                List<ContentletSearch> searchResults = APILocator.getContentletAPI().searchIndex(embeddingsForm.query + " +live:true", embeddingsForm.limit, newOffset, "moddate", user, false);
                 if (searchResults.isEmpty()) {
                     break;
                 }

--- a/src/main/java/com/dotcms/ai/rest/forms/CompletionsForm.java
+++ b/src/main/java/com/dotcms/ai/rest/forms/CompletionsForm.java
@@ -117,7 +117,7 @@ public class CompletionsForm {
                 : builder.temperature >= 2
                     ? 2
                     : builder.temperature;
-        this.model = UtilMethods.isSet(builder.model) ? builder.model : ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_MODEL);
+        this.model = UtilMethods.isSet(builder.model) ? builder.model : ConfigService.INSTANCE.config().getConfig(AppKeys.MODEL);
     }
 
     String validateBuilderQuery(String query) {

--- a/src/main/java/com/dotcms/ai/service/OpenAIImageServiceImpl.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIImageServiceImpl.java
@@ -79,7 +79,6 @@ public class OpenAIImageServiceImpl implements OpenAIImageService {
                 returnObject.put("originalPrompt", jsonObject.getString("prompt"));
             }
             return returnObject;
-            //return createTempFile(returnObject);
 
         } catch (Exception e) {
             Logger.warn(this.getClass(), "image request failed:" + e.getMessage(),e);

--- a/src/main/java/com/dotcms/ai/service/OpenAIImageServiceImpl.java
+++ b/src/main/java/com/dotcms/ai/service/OpenAIImageServiceImpl.java
@@ -78,8 +78,8 @@ public class OpenAIImageServiceImpl implements OpenAIImageService {
                 returnObject = returnObject.getJSONArray("data").getJSONObject(0);
                 returnObject.put("originalPrompt", jsonObject.getString("prompt"));
             }
-
-            return createTempFile(returnObject);
+            return returnObject;
+            //return createTempFile(returnObject);
 
         } catch (Exception e) {
             Logger.warn(this.getClass(), "image request failed:" + e.getMessage(),e);

--- a/src/main/java/com/dotcms/ai/viewtool/CompletionsTool.java
+++ b/src/main/java/com/dotcms/ai/viewtool/CompletionsTool.java
@@ -50,8 +50,8 @@ public class CompletionsTool implements ViewTool {
                 this.app.getConfig(AppKeys.COMPLETION_ROLE_PROMPT),
                 AppKeys.COMPLETION_TEXT_PROMPT.key,
                 this.app.getConfig(AppKeys.COMPLETION_TEXT_PROMPT),
-                AppKeys.COMPLETION_MODEL.key,
-                this.app.getConfig(AppKeys.COMPLETION_MODEL)
+                AppKeys.MODEL.key,
+                this.app.getConfig(AppKeys.MODEL)
         );
 
     }

--- a/src/main/java/com/dotcms/ai/workflow/OpenAIAutoTagActionlet.java
+++ b/src/main/java/com/dotcms/ai/workflow/OpenAIAutoTagActionlet.java
@@ -48,7 +48,7 @@ public class OpenAIAutoTagActionlet extends WorkFlowActionlet {
                 limitTagsToHost,
 
                 new WorkflowActionletParameter(OpenAIParams.RUN_DELAY.key, "Update the content asynchronously, after X seconds. O means run in-process", "5", true),
-                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_MODEL), ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_MODEL), false),
+                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.MODEL), ConfigService.INSTANCE.config().getConfig(AppKeys.MODEL), false),
                 new WorkflowActionletParameter(OpenAIParams.TEMPERATURE.key, "The AI temperature for the response.  Between .1 and 2.0.", ".1", false)
         );
     }

--- a/src/main/java/com/dotcms/ai/workflow/OpenAIContentPromptActionlet.java
+++ b/src/main/java/com/dotcms/ai/workflow/OpenAIContentPromptActionlet.java
@@ -43,7 +43,7 @@ public class OpenAIContentPromptActionlet extends WorkFlowActionlet {
                 overwriteParameter,
                 new WorkflowActionletParameter(OpenAIParams.OPEN_AI_PROMPT.key, "The prompt that will be sent to the AI", "We need an attractive search result in Google. Return a json object that includes the fields \"pageTitle\" for a meta title of less than 55 characters and \"metaDescription\" for the meta description of less than 300 characters using this content:\\n\\n${fieldContent}\\n\\n", true),
                 new WorkflowActionletParameter(OpenAIParams.RUN_DELAY.key, "Update the content asynchronously, after X seconds. O means run in-process", "5", true),
-                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_MODEL), ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_MODEL), false),
+                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.MODEL), ConfigService.INSTANCE.config().getConfig(AppKeys.MODEL), false),
                 new WorkflowActionletParameter(OpenAIParams.TEMPERATURE.key, "The AI temperature for the response.  Between .1 and 2.0.  Defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_TEMPERATURE), ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_TEMPERATURE), false)
         );
     }


### PR DESCRIPTION
This PR does a few things
1. It allows for an external/other postgres DB to be configured/overridden for all AI DB actions
2. it will only add live content to an index - this will prevent working content from making into an index
3. it fixes a pagination logic error when deleting a lot of content from an embeddings index by query (> 100 pieces of content)
4. it removes the duplicate `completions.model` configuration key and standardizes it on the main config `model`.

#### DB Config Override
```
DOT_AI_DB_BASE_URL=DB Url
DOT_AI_DB_USERNAME=XXXXXX
DOT_AI_DB_PASSWORD=XXXXXX
DOT_AI_DB_MAX_TOTAL=(default 50)
```
